### PR TITLE
Add `jest-mock` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cp": "cpy dist ../../../test/storybook-module-mock/node_modules/storybook-addon-module-mock"
   },
   "dependencies": {
+    "jest-mock": "^27.3.0",
     "minimatch": "^9.0.3",
     "react-json-tree": "^0.18.0"
   },


### PR DESCRIPTION
Fix #17 

暗黙的に依存していた `jest-mock` を依存に追加しました。

最新バージョンではなく、 `@storybook/jest` によってインストールされている `^27.3.0` を追加しています。